### PR TITLE
Added end point for single notebook linter

### DIFF
--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, File, UploadFile
+from typing import Optional
+import os
+import pynblint
+import shutil
+import config
+
+app = FastAPI()
+
+
+@app.get('/')
+def index():
+    return {'data': {'message': 'Welcome to the pynblint API'}}
+
+@app.post("/linters/nb-linter/")
+async def nb_lint(notebook: UploadFile = File(...), bottom_size: Optional[int] = 4):
+    with open(config.data_path+notebook.filename, "wb") as buffer:
+        shutil.copyfileobj(notebook.file, buffer)
+    script = pynblint.notebook_to_script(notebook.filename)
+    nb_dict = pynblint.notebook_to_dict(notebook.filename)
+    response = {
+        "data": {
+            "fileName": notebook.filename,
+            "linearExecutionOrder": pynblint.has_linear_execution_order(nb_dict),
+            "numberOfClassDefinitions": pynblint.count_class_defs(script),
+            "numberOfFunctionDefinitions": pynblint.count_func_defs(script),
+            "allImportsInFirstCell": pynblint.are_imports_in_first_cell(script),
+            "numberOfMarkdownLines": pynblint.count_md_lines(nb_dict),
+            "numberOfMarkdownTitles": pynblint.count_md_titles(nb_dict),
+            "bottomMarkdownLinesRatio": pynblint.get_bottom_md_lines_ratio(nb_dict),
+            "nonExecutedCells": pynblint.count_non_executed_cells(nb_dict),
+            "emptyCells: ": pynblint.count_empty_cells(nb_dict),
+            "bottomNonExecutedCells": pynblint.count_bottom_non_executed_cells(nb_dict, bottom_size),
+            "bottomEmptyCells": pynblint.count_bottom_empty_cells(nb_dict, bottom_size)
+        }
+    }
+    os.remove(config.data_path+notebook.filename)
+    os.remove(notebook.filename[:-5] + "py")
+    return response

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -13,7 +13,7 @@ def index():
     return {'data': {'message': 'Welcome to the pynblint API'}}
 
 @app.post("/linters/nb-linter/")
-async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(...)):
+async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(4)):
     with open(config.data_path+notebook.filename, "wb") as buffer:
         shutil.copyfileobj(notebook.file, buffer)
     script = pynblint.notebook_to_script(notebook.filename)


### PR DESCRIPTION
Ora tramite il seguente comando:
```
curl -X 'POST' \
  'http://127.0.0.1:8000/linters/nb-linter/' \
  -H 'accept: application/json' \
  -H 'Content-Type: multipart/form-data' \
  -F 'notebook=@my-attempt-at-analytics-vidhya-job-a-thon.ipynb'
```
è possibile avere una risposta contenente:
```
{
  "data": {
    "fileName": "my-attempt-at-analytics-vidhya-job-a-thon.ipynb",
    "linearExecutionOrder": true,
    "numberOfClassDefinitions": 0,
    "numberOfFunctionDefinitions": 3,
    "allImportsInFirstCell": false,
    "numberOfMarkdownLines": 7,
    "numberOfMarkdownTitles": 2,
    "bottomMarkdownLinesRatio": 0,
    "nonExecutedCells": 0,
    "emptyCells: ": 3,
    "bottomNonExecutedCells": 0,
    "bottomEmptyCells": 2
  }
}
```
E' anche possibile specificare come query parameter il bottom_size che andrà ad agire sull'analisi di celle vuote e non eseguite nelle ultime bottom_size celle del notebook.

```'http://127.0.0.1:8000/linters/nb-linter/?bottom_size=10' \```

 In caso di mancanza del parametro, si procederà all'analisi con valore di default 4, come concordato.

La funzione procederà, dopo l'analisi del notebook, alla sua cancellazione sul server.

Ho deciso di non inserire in questo endpoint dati sul numero di celle, numero di celle di md, numero di celle di codice e numero di celle raw, in quanto secondo me dovrebbero essere su endpoint a parte non fornendo effettivamente informazioni utili al linting del notebook.
