### PR TITLE
Add end-point for repo linting

### DIFF
--- a/NotebookAnalyzers/entities.py
+++ b/NotebookAnalyzers/entities.py
@@ -93,6 +93,13 @@ class Repository:
     # Extracted content
     notebooks: list[Notebook] = []  # List of Notebook objects
 
+    def get_pynblint_results(self):
+        """Function takes a list of notebook objects and returns a list of dictionaries containg the linting results"""
+        data = []
+        for notebook in self.notebooks:
+            data.append(notebook.get_pynblint_results())
+        return {"data": data}
+
     def retrieve_notebooks(self):
 
         # Directories to ignore while traversing the tree

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -32,7 +32,7 @@ async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(4)):
     return nb.get_pynblint_results()
 
 
-@app.post("/linters/repo-linter/")
+@app.get("/linters/repo-linter/")
 def repo_lint(repo_url: str):
     data=[]
     repo = GitHubRepository(repo_url)

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -17,12 +17,6 @@ linters_dict = {
     'repo-linter': repo_linter
 }
 
-def _lint_notebooks_list(nb_objects):
-    """Function take a list of notebook objects and returns a list of dictionaries containg the linting results"""
-    data=[]
-    for notebook in nb_objects:
-        data.append(notebook.get_pynblint_results())
-    return {"data": data}
 
 @app.get('/')
 def index():
@@ -41,7 +35,7 @@ async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(4)):
 @app.get("/linters/repo-linter/")
 def repo_lint(repo_url: str):
     repo = GitHubRepository(repo_url)
-    return _lint_notebooks_list(repo.notebooks)
+    return repo.get_pynblint_results()
 
 
 @app.get('/linters/{linter_id}')

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -17,6 +17,12 @@ linters_dict = {
     'repo-linter': repo_linter
 }
 
+def _lint_notebooks_list(nb_objects):
+    """Function take a list of notebook objects and returns a list of dictionaries containg the linting results"""
+    data=[]
+    for notebook in nb_objects:
+        data.append(notebook.get_pynblint_results())
+    return {"data": data}
 
 @app.get('/')
 def index():
@@ -34,11 +40,8 @@ async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(4)):
 
 @app.get("/linters/repo-linter/")
 def repo_lint(repo_url: str):
-    data=[]
     repo = GitHubRepository(repo_url)
-    for notebook in repo.notebooks:
-        data.append(notebook.get_pynblint_results())
-    return {"data": data}
+    return _lint_notebooks_list(repo.notebooks)
 
 
 @app.get('/linters/{linter_id}')

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -32,6 +32,15 @@ async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(4)):
     return nb.get_pynblint_results()
 
 
+@app.post("/linters/repo-linter/")
+def repo_lint(repo_url: str):
+    data=[]
+    repo = GitHubRepository(repo_url)
+    for notebook in repo.notebooks:
+        data.append(notebook.get_pynblint_results())
+    return {"data": data}
+
+
 @app.get('/linters/{linter_id}')
 def get_linter(linter_id: str):
     if linter_id in linters_dict:


### PR DESCRIPTION
Using:
```
curl -X 'GET' \
  'http://127.0.0.1:8000/linters/repo-linter/?repo_url=https%3A%2F%2Fgithub.com%2Fcollab-uniba%2FSentiment_Analysis_4SE_BERT' \
  -H 'accept: application/json' \
  -d ''
```
Is now possible to request the linting of a public github repo, and, in this case of the Sentiment_Analysis_4SE_BERT repo to get the following response
```
{
  "data": [
    {
      "notebookName": "Sentiment_Analysis_4SE_BERT\\notebooks\\cross-platform-w-bert.ipynb",
      "notebookStats": {
        "numberOfCells": 13,
        "numberOfMDCells": 0,
        "numberOfCodeCells": 13,
        "numberOfRawCells": 0
      },
      "lintingResults": {
        "linearExecutionOrder": true,
        "numberOfClassDefinitions": 0,
        "numberOfFunctionDefinitions": 0,
        "allImportsInFirstCell": false,
        "numberOfMarkdownLines": 0,
        "numberOfMarkdownTitles": 0,
        "bottomMarkdownLinesRatio": 0,
        "nonExecutedCells": 0,
        "emptyCells": 0,
        "bottomNonExecutedCells": 0,
        "bottomEmptyCells": 0
      }
    },
    {
      "notebookName": "Sentiment_Analysis_4SE_BERT\\notebooks\\github-w-bert.ipynb",
      "notebookStats": {
        "numberOfCells": 17,
        "numberOfMDCells": 0,
        "numberOfCodeCells": 17,
        "numberOfRawCells": 0
      },
      "lintingResults": {
        "linearExecutionOrder": true,
        "numberOfClassDefinitions": 0,
        "numberOfFunctionDefinitions": 0,
        "allImportsInFirstCell": false,
        "numberOfMarkdownLines": 0,
        "numberOfMarkdownTitles": 0,
        "bottomMarkdownLinesRatio": 0,
        "nonExecutedCells": 0,
        "emptyCells": 0,
        "bottomNonExecutedCells": 0,
        "bottomEmptyCells": 0
      }
    },
    ...
}
```
