### PR TITLE
Added end-point for linting a local repository as a .zip file

### DIFF
--- a/NotebookAnalyzers/entities.py
+++ b/NotebookAnalyzers/entities.py
@@ -93,6 +93,14 @@ class Repository:
     # Extracted content
     notebooks: list[Notebook] = []  # List of Notebook objects
 
+    def get_pynblint_results(self):
+        """Function takes a list of notebook objects and returns a list of dictionaries containg the linting results"""
+        data = []
+        for notebook in self.notebooks:
+            data.append(notebook.get_pynblint_results())
+        return {"data": data}
+
+
     def retrieve_notebooks(self):
 
         # Directories to ignore while traversing the tree

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -18,14 +18,6 @@ linters_dict = {
 }
 
 
-def _lint_notebooks_list(nb_objects):
-    """Function take a list of notebook objects and returns a list of dictionaries containg the linting results"""
-    data=[]
-    for notebook in nb_objects:
-        data.append(notebook.get_pynblint_results())
-    return {"data": data}
-
-
 @app.get('/')
 def index():
     return {'data': {'message': 'Welcome to the pynblint API'}}
@@ -46,7 +38,7 @@ async def nb_lint(local_project: UploadFile = File(...), bottom_size: int = Form
     try:
         project = LocalRepository(Path(config.data_path) / local_project.filename)
         os.remove(Path(config.data_path) / local_project.filename)
-        return _lint_notebooks_list(project.notebooks)
+        return project.get_pynblint_results()
     except Exception:
         os.remove(Path(config.data_path) / local_project.filename)
         raise HTTPException(status_code=400, detail="Bad request")

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -43,9 +43,13 @@ async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(4)):
 async def nb_lint(local_project: UploadFile = File(...), bottom_size: int = Form(4)):
     with open( Path(config.data_path) / local_project.filename, "wb") as buffer:
         shutil.copyfileobj(local_project.file, buffer)
-    project = LocalRepository(Path(config.data_path) / local_project.filename)
-    os.remove(Path(config.data_path) / local_project.filename)
-    return _lint_notebooks_list(project.notebooks)
+    try:
+        project = LocalRepository(Path(config.data_path) / local_project.filename)
+        os.remove(Path(config.data_path) / local_project.filename)
+        return _lint_notebooks_list(project.notebooks)
+    except Exception:
+        os.remove(Path(config.data_path) / local_project.filename)
+        raise HTTPException(status_code=400, detail="Bad request")
 
 @app.get('/linters/{linter_id}')
 def get_linter(linter_id: str):

--- a/NotebookAnalyzers/main.py
+++ b/NotebookAnalyzers/main.py
@@ -18,6 +18,14 @@ linters_dict = {
 }
 
 
+def _lint_notebooks_list(nb_objects):
+    """Function take a list of notebook objects and returns a list of dictionaries containg the linting results"""
+    data=[]
+    for notebook in nb_objects:
+        data.append(notebook.get_pynblint_results())
+    return {"data": data}
+
+
 @app.get('/')
 def index():
     return {'data': {'message': 'Welcome to the pynblint API'}}
@@ -31,6 +39,13 @@ async def nb_lint(notebook: UploadFile = File(...), bottom_size: int = Form(4)):
     os.remove(Path(config.data_path) / notebook.filename)
     return nb.get_pynblint_results()
 
+@app.post("/linters/repo-linter/")
+async def nb_lint(local_project: UploadFile = File(...), bottom_size: int = Form(4)):
+    with open( Path(config.data_path) / local_project.filename, "wb") as buffer:
+        shutil.copyfileobj(local_project.file, buffer)
+    project = LocalRepository(Path(config.data_path) / local_project.filename)
+    os.remove(Path(config.data_path) / local_project.filename)
+    return _lint_notebooks_list(project.notebooks)
 
 @app.get('/linters/{linter_id}')
 def get_linter(linter_id: str):


### PR DESCRIPTION
Using:
```
curl -X 'POST' \
  'http://127.0.0.1:8000/linters/repo-linter/' \
  -H 'accept: application/json' \
  -H 'Content-Type: multipart/form-data' \
  -F 'local_project=@Sentiment_Analysis_4SE_BERT-master.zip;type=application/x-zip-compressed' \
  -F 'bottom_size=4' 
```
Is now possible to request the linting of a local project as a .zip file, and, in this case of the Sentiment_Analysis_4SE_BERT to get the following response:
```
{
  "data": [
    {
      "notebookName": "Sentiment_Analysis_4SE_BERT\\notebooks\\cross-platform-w-bert.ipynb",
      "notebookStats": {
        "numberOfCells": 13,
        "numberOfMDCells": 0,
        "numberOfCodeCells": 13,
        "numberOfRawCells": 0
      },
      "lintingResults": {
        "linearExecutionOrder": true,
        "numberOfClassDefinitions": 0,
        "numberOfFunctionDefinitions": 0,
        "allImportsInFirstCell": false,
        "numberOfMarkdownLines": 0,
        "numberOfMarkdownTitles": 0,
        "bottomMarkdownLinesRatio": 0,
        "nonExecutedCells": 0,
        "emptyCells": 0,
        "bottomNonExecutedCells": 0,
        "bottomEmptyCells": 0
      }
    },
    {
      "notebookName": "Sentiment_Analysis_4SE_BERT\\notebooks\\github-w-bert.ipynb",
      "notebookStats": {
        "numberOfCells": 17,
        "numberOfMDCells": 0,
        "numberOfCodeCells": 17,
        "numberOfRawCells": 0
      },
      "lintingResults": {
        "linearExecutionOrder": true,
        "numberOfClassDefinitions": 0,
        "numberOfFunctionDefinitions": 0,
        "allImportsInFirstCell": false,
        "numberOfMarkdownLines": 0,
        "numberOfMarkdownTitles": 0,
        "bottomMarkdownLinesRatio": 0,
        "nonExecutedCells": 0,
        "emptyCells": 0,
        "bottomNonExecutedCells": 0,
        "bottomEmptyCells": 0
      }
    },
    ...
}
```