### PR TITLE
Improve test coverage checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
+!tests/fixtures/test_repo/versioned_repo_with_coverage/.coverage
 .cache
 nosetests.xml
 coverage.xml

--- a/pynblint/repo_linting.py
+++ b/pynblint/repo_linting.py
@@ -35,6 +35,17 @@ def dependencies_unmanaged(repo: Repository) -> bool:
     return not any(map(lambda x: x.exists(), paths))
 
 
+def coverage_data_not_available(repo: Repository) -> bool:
+    """Check the absence of coverage data produced by ``coverage.py``.
+
+    The absence of coverage data is considered a hint that the project
+    might be not tested.
+    """
+
+    path = repo.path / ".coverage"
+    return not path.exists()
+
+
 # ========== #
 # PATH LEVEL #
 # ========== #
@@ -101,6 +112,15 @@ project_level_lints: List[LintDefinition] = [
         "`requirements.txt` file.\nYou can do so by running the following command: "
         "`pip freeze > requirements.txt`.",
         linting_function=dependencies_unmanaged,
+    ),
+    LintDefinition(
+        slug="test-coverage-data-not-available",
+        description="Test coverage data is not available in the current repository "
+        "(i.e., there is no `.coverage` file in the project root path).",
+        recommendation="Make sure that your code is properly tested. "
+        "If the testing framework that you are using does not produce a `.coverage` "
+        "data file, please ignore this warning.",
+        linting_function=coverage_data_not_available,
     ),
 ]
 

--- a/tests/unit/test_repo_linting_functions.py
+++ b/tests/unit/test_repo_linting_functions.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from pynblint import repo_linting
+from pynblint.core_models import Repository
+
+
+@pytest.fixture(scope="module")
+def repositories() -> Dict[str, Repository]:
+
+    repo_fixtures_base_path: Path = Path("tests/fixtures/test_repo")
+
+    repo1 = Repository(repo_fixtures_base_path / "UntitledNoDuplicates")
+    repo2 = Repository(repo_fixtures_base_path / "versioned_repo_with_coverage")
+    return {
+        "UntitledNoDuplicates": repo1,
+        "versioned_repo_with_coverage": repo2,
+    }
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [("UntitledNoDuplicates", True), ("versioned_repo_with_coverage", False)],
+)
+def test_coverage_data_not_available(test_input, expected, repositories):
+    assert (
+        repo_linting.coverage_data_not_available(repositories[test_input]) == expected
+    )


### PR DESCRIPTION
This new linting check ensures that coverage data have been saved in the project root directory (i.e., that a `.coverage` file, produced by `coverage.py`, can be retrieved therein). 

Replaces #90 in closing #81.